### PR TITLE
Add email blast tools for RSVPs

### DIFF
--- a/docs/rsvp-admin-guide.md
+++ b/docs/rsvp-admin-guide.md
@@ -92,6 +92,7 @@ Configure labels for the following form fields:
    - Customize email template
    - Preview email content
    - Test email delivery
+   - Send email blast to all RSVPs
    - Automatic sending on RSVP submission
 
 ## Data Export

--- a/migrations/007_add_email_to_guest_list.sql
+++ b/migrations/007_add_email_to_guest_list.sql
@@ -1,0 +1,5 @@
+-- Add email column to guest_list table
+ALTER TABLE guest_list ADD COLUMN email TEXT;
+
+-- Create an index on email for faster lookups
+CREATE INDEX idx_guest_list_email ON guest_list(email); 

--- a/src/lib/db/migrations/006_add_email_template_types.sql
+++ b/src/lib/db/migrations/006_add_email_template_types.sql
@@ -1,0 +1,27 @@
+-- Add template_type column to email_templates table (if it doesn't exist)
+ALTER TABLE email_templates ADD COLUMN template_type TEXT DEFAULT 'confirmation';
+
+-- Update existing templates to be confirmation type
+UPDATE email_templates SET template_type = 'confirmation' WHERE template_type IS NULL;
+
+-- Keep only the most recent template and mark it as confirmation
+DELETE FROM email_templates WHERE id NOT IN (
+  SELECT id FROM email_templates ORDER BY created_at DESC LIMIT 1
+);
+
+-- Insert default blast template (only if it doesn't exist)
+INSERT OR IGNORE INTO email_templates (template, template_type) VALUES (
+  '<h2>Important Wedding Update</h2>
+  <p>Dear Wedding Guests,</p>
+  
+  <p>We wanted to share some important information about our upcoming wedding celebration.</p>
+  
+  <p>Please feel free to reach out if you have any questions.</p>
+  
+  <p>Looking forward to celebrating with you!</p>
+  <p>Connor & Colette</p>',
+  'blast'
+);
+
+-- Create unique constraint on template_type to ensure only one template per type
+CREATE UNIQUE INDEX idx_email_templates_type ON email_templates(template_type); 

--- a/src/lib/db/schema.sql
+++ b/src/lib/db/schema.sql
@@ -26,6 +26,7 @@ DROP TABLE IF EXISTS guest_list;
 CREATE TABLE guest_list (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT NOT NULL,
+  email TEXT,
   partner_name TEXT,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
@@ -35,3 +36,6 @@ CREATE INDEX idx_guest_list_name ON guest_list(name);
 
 -- Create an index on partner_name for faster lookups
 CREATE INDEX idx_guest_list_partner_name ON guest_list(partner_name);
+
+-- Create an index on email for faster lookups
+CREATE INDEX idx_guest_list_email ON guest_list(email);

--- a/src/lib/services/email.js
+++ b/src/lib/services/email.js
@@ -1,17 +1,18 @@
 export async function buildRsvpEmailContent(
   rsvpData,
   platform,
-  templateOverride = null
+  templateOverride = null,
+  templateType = 'confirmation'
 ) {
-  console.log('Building RSVP email content for:', rsvpData.name);
+  console.log('Building RSVP email content for:', rsvpData.name, 'with template type:', templateType);
 
-  // Get the latest email template if not provided
+  // Get the template for the specified type if not provided
   let templateResult = null;
   if (!templateOverride) {
-    console.log('Fetching email template...');
+    console.log('Fetching email template for type:', templateType);
     templateResult = await platform.env.RSVPS.prepare(
-      'SELECT template FROM email_templates ORDER BY created_at DESC LIMIT 1'
-    ).first();
+      'SELECT template FROM email_templates WHERE template_type = ? ORDER BY created_at DESC LIMIT 1'
+    ).bind(templateType).first();
     console.log('Template result:', templateResult);
   }
 
@@ -138,7 +139,7 @@ export async function sendRsvpConfirmationEmail(rsvpData, platform, overrideEmai
     email: overrideEmail || rsvpData.email
   });
 
-  const emailContent = await buildRsvpEmailContent(rsvpData, platform, templateOverride);
+  const emailContent = await buildRsvpEmailContent(rsvpData, platform, templateOverride, 'confirmation');
 
   console.log('Sending email via Brevo API...');
   const response = await fetch('https://api.brevo.com/v3/smtp/email', {
@@ -183,7 +184,7 @@ export async function sendEmailBlast(platform, templateOverride = null) {
   let sent = 0;
   for (const rsvp of results.results) {
     try {
-      await sendRsvpConfirmationEmail(rsvp, platform, null, templateOverride);
+      await sendBlastEmail(rsvp, platform, null, templateOverride);
       sent++;
     } catch (err) {
       console.error('Failed to send email to', rsvp.email, err);
@@ -191,5 +192,68 @@ export async function sendEmailBlast(platform, templateOverride = null) {
   }
 
   return { total: results.results.length, sent };
+}
+
+export async function sendBlastEmail(rsvpData, platform, overrideEmail = null, templateOverride = null) {
+  console.log('Starting blast email send process for:', {
+    name: rsvpData.name,
+    email: overrideEmail || rsvpData.email
+  });
+
+  // For blast emails, we don't include form data - just use the template as-is
+  let emailContent;
+  if (templateOverride) {
+    emailContent = templateOverride;
+  } else {
+    const templateResult = await platform.env.RSVPS.prepare(
+      'SELECT template FROM email_templates WHERE template_type = ? ORDER BY created_at DESC LIMIT 1'
+    ).bind('blast').first();
+    
+    emailContent = templateResult?.template || `
+      <h2>Important Wedding Update</h2>
+      <p>Dear Wedding Guests,</p>
+      
+      <p>We wanted to share some important information about our upcoming wedding celebration.</p>
+      
+      <p>Please feel free to reach out if you have any questions.</p>
+      
+      <p>Looking forward to celebrating with you!</p>
+      <p>Connor & Colette</p>
+    `;
+  }
+
+  console.log('Sending blast email via Brevo API...');
+  const response = await fetch('https://api.brevo.com/v3/smtp/email', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'api-key': platform.env.BREVO_API_KEY
+    },
+    body: JSON.stringify({
+      sender: {
+        name: platform.env.EMAIL_SENDER_NAME,
+        email: platform.env.EMAIL_SENDER_ADDRESS
+      },
+      to: [
+        {
+          email: overrideEmail || rsvpData.email,
+          name: rsvpData.name
+        }
+      ],
+      subject: 'Wedding Update - Connor & Colette',
+      htmlContent: emailContent
+    })
+  });
+
+  console.log('Brevo API response status:', response.status);
+  const responseData = await response.json();
+  console.log('Brevo API response:', responseData);
+
+  if (!response.ok) {
+    throw new Error(`Failed to send email: ${responseData.message}`);
+  }
+
+  return responseData;
 }
 

--- a/src/routes/admin/guest-list/+page.svelte
+++ b/src/routes/admin/guest-list/+page.svelte
@@ -11,6 +11,7 @@
   let addingGuest = false;
   let newGuest = {
     name: '',
+    email: '',
     partner_name: ''
   };
   let showDeleteConfirm = false;
@@ -93,6 +94,7 @@
       await loadGuests();
       newGuest = {
         name: '',
+        email: '',
         partner_name: ''
       };
       addingGuest = false;
@@ -194,6 +196,16 @@
             />
           </div>
           <div class="md:col-span-2">
+            <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email (for save the dates and updates)</label>
+            <input
+              type="email"
+              id="email"
+              bind:value={newGuest.email}
+              class="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-opacity-50"
+              style="focus-ring-color: var(--color-primary)"
+            />
+          </div>
+          <div class="md:col-span-2">
             <label for="partner_name" class="block text-sm font-medium text-gray-700 mb-1"
               >Partner/Spouse Name (if applicable)</label
             >
@@ -224,6 +236,7 @@
         <thead class="bg-gray-50">
           <tr>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Partner</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
           </tr>
@@ -232,6 +245,7 @@
           {#each guests as guest}
             <tr class="hover:bg-gray-50">
               <td class="px-6 py-4 whitespace-nowrap">{guest.name}</td>
+              <td class="px-6 py-4 whitespace-nowrap">{guest.email || '-'}</td>
               <td class="px-6 py-4 whitespace-nowrap">{guest.partner_name || '-'}</td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <button
@@ -256,20 +270,21 @@
         <thead>
           <tr>
             <th class="px-4 py-2 border">name</th>
+            <th class="px-4 py-2 border">email</th>
             <th class="px-4 py-2 border">partner_name</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td class="px-4 py-2 border">John Smith</td>
+            <td class="px-4 py-2 border">john@example.com</td>
             <td class="px-4 py-2 border">Jane Smith</td>
           </tr>
         </tbody>
       </table>
     </div>
     <p class="text-gray-600 mt-4">
-      Note: Only the 'name' column is required. 'partner_name' is optional for guests with a
-      partner/spouse.
+      Note: Only the 'name' column is required. 'email' and 'partner_name' are optional. The email field will be used for save the dates and other wedding updates.
     </p>
   </div>
 </div>

--- a/src/routes/api/admin/email-blast/+server.js
+++ b/src/routes/api/admin/email-blast/+server.js
@@ -1,0 +1,21 @@
+import { sendEmailBlast } from '$lib/services/email';
+
+export async function POST({ request, platform }) {
+  const jsonResponse = (data, status = 200) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+  const jwt = request.headers.get('Cf-Access-Jwt-Assertion');
+  if (!jwt) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  try {
+    const { template } = await request.json();
+    const result = await sendEmailBlast(platform, template);
+    return jsonResponse({ success: true, ...result });
+  } catch (error) {
+    console.error('Error sending email blast:', error);
+    return jsonResponse({ error: 'Failed to send emails' }, 500);
+  }
+}

--- a/src/routes/api/admin/email-preview/+server.js
+++ b/src/routes/api/admin/email-preview/+server.js
@@ -11,20 +11,35 @@ export async function POST({ request, platform }) {
   if (!jwt) return jsonResponse({ error: 'Unauthorized' }, 401);
 
   try {
-    const { template } = await request.json();
-    let rsvp = await platform.env.RSVPS.prepare(
-      "SELECT * FROM rsvps WHERE email IS NOT NULL AND email <> '' ORDER BY created_at DESC LIMIT 1"
-    ).first();
+    const { template, templateType } = await request.json();
+    
+    let html;
+    if (templateType === 'blast') {
+      // For blast emails, just return the template as-is (no form data)
+      html = template || '<p>No template content</p>';
+    } else {
+      // For confirmation emails, build with form data
+      let rsvp = await platform.env.RSVPS.prepare(
+        "SELECT * FROM rsvps WHERE email IS NOT NULL AND email <> '' ORDER BY created_at DESC LIMIT 1"
+      ).first();
 
-    if (!rsvp) {
-      rsvp = {
-        name: 'Test Guest',
-        email: 'test@example.com',
-        attending: 'yes'
-      };
+      if (!rsvp) {
+        rsvp = {
+          name: 'Test Guest',
+          email: 'test@example.com',
+          attending: 'yes',
+          is_vegetarian: 'no',
+          food_allergies: 'None',
+          lodging: 'yes',
+          using_transport: 'yes',
+          song: 'Your Song by Elton John',
+          special_notes: 'Looking forward to celebrating with you!'
+        };
+      }
+
+      html = await buildRsvpEmailContent(rsvp, platform, template, 'confirmation');
     }
-
-    const html = await buildRsvpEmailContent(rsvp, platform, template);
+    
     return jsonResponse({ html });
   } catch (error) {
     console.error('Error building email preview:', error);

--- a/src/routes/api/admin/email-preview/+server.js
+++ b/src/routes/api/admin/email-preview/+server.js
@@ -1,0 +1,33 @@
+import { buildRsvpEmailContent } from '$lib/services/email';
+
+export async function POST({ request, platform }) {
+  const jsonResponse = (data, status = 200) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+  const jwt = request.headers.get('Cf-Access-Jwt-Assertion');
+  if (!jwt) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  try {
+    const { template } = await request.json();
+    let rsvp = await platform.env.RSVPS.prepare(
+      "SELECT * FROM rsvps WHERE email IS NOT NULL AND email <> '' ORDER BY created_at DESC LIMIT 1"
+    ).first();
+
+    if (!rsvp) {
+      rsvp = {
+        name: 'Test Guest',
+        email: 'test@example.com',
+        attending: 'yes'
+      };
+    }
+
+    const html = await buildRsvpEmailContent(rsvp, platform, template);
+    return jsonResponse({ html });
+  } catch (error) {
+    console.error('Error building email preview:', error);
+    return jsonResponse({ error: 'Failed to build preview' }, 500);
+  }
+}

--- a/src/routes/api/admin/guest-list/+server.js
+++ b/src/routes/api/admin/guest-list/+server.js
@@ -6,6 +6,7 @@ export async function GET({ platform }) {
       CREATE TABLE IF NOT EXISTS guest_list (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT NOT NULL,
+        email TEXT,
         partner_name TEXT,
         plus_one_allowed BOOLEAN DEFAULT FALSE,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -40,6 +41,7 @@ export async function POST({ request, platform }) {
       CREATE TABLE IF NOT EXISTS guest_list (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT NOT NULL,
+        email TEXT,
         partner_name TEXT,
         plus_one_allowed BOOLEAN DEFAULT FALSE,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -74,12 +76,13 @@ export async function POST({ request, platform }) {
       `
       INSERT INTO guest_list (
         name,
+        email,
         partner_name,
         plus_one_allowed
-      ) VALUES (?, ?, ?)
+      ) VALUES (?, ?, ?, ?)
       `
     )
-      .bind(guest.name, guest.partner_name || null, guest.plus_one_allowed ? 1 : 0)
+      .bind(guest.name, guest.email || null, guest.partner_name || null, guest.plus_one_allowed ? 1 : 0)
       .run();
 
     return new Response(JSON.stringify({ success: true }), {

--- a/src/routes/api/admin/guest-list/upload/+server.js
+++ b/src/routes/api/admin/guest-list/upload/+server.js
@@ -81,11 +81,16 @@ export async function POST({ request, platform }) {
           `
           INSERT INTO guest_list (
             name,
+            email,
             partner_name
-          ) VALUES (?, ?)
+          ) VALUES (?, ?, ?)
           `
         )
-          .bind(record.name?.trim(), record.partner_name?.trim() || null)
+          .bind(
+            record.name?.trim(), 
+            record.email?.trim() || null, 
+            record.partner_name?.trim() || null
+          )
           .run();
         processedCount++;
       } catch (recordError) {

--- a/src/routes/api/admin/send-test-email/+server.js
+++ b/src/routes/api/admin/send-test-email/+server.js
@@ -1,0 +1,30 @@
+import { sendRsvpConfirmationEmail } from '$lib/services/email';
+
+export async function POST({ request, platform }) {
+  const jsonResponse = (data, status = 200) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json' }
+    });
+
+  const jwt = request.headers.get('Cf-Access-Jwt-Assertion');
+  if (!jwt) return jsonResponse({ error: 'Unauthorized' }, 401);
+
+  try {
+    const { email } = await request.json();
+    if (!email) return jsonResponse({ error: 'Email is required' }, 400);
+
+    let rsvp = await platform.env.RSVPS.prepare(
+      "SELECT * FROM rsvps WHERE email IS NOT NULL AND email <> '' ORDER BY created_at DESC LIMIT 1"
+    ).first();
+    if (!rsvp) {
+      rsvp = { name: 'Test Guest', email, attending: 'yes' };
+    }
+
+    await sendRsvpConfirmationEmail(rsvp, platform, email);
+    return jsonResponse({ success: true });
+  } catch (error) {
+    console.error('Error sending test email:', error);
+    return jsonResponse({ error: 'Failed to send test email' }, 500);
+  }
+}

--- a/src/routes/api/rsvp/+server.js
+++ b/src/routes/api/rsvp/+server.js
@@ -102,6 +102,21 @@ export async function POST({ request, platform }) {
       );
     }
 
+    // Update guest list email if it's different or empty
+    if (primary.email && primary.email !== guestCheck.email) {
+      try {
+        await platform.env.RSVPS.prepare(
+          'UPDATE guest_list SET email = ? WHERE id = ?'
+        )
+          .bind(primary.email, guestCheck.id)
+          .run();
+        console.log(`[${requestId}] Updated guest list email for ${primary.name}`);
+      } catch (emailUpdateError) {
+        console.warn(`[${requestId}] Failed to update guest list email:`, emailUpdateError);
+        // Don't fail the request if guest list update fails
+      }
+    }
+
     // Check if this is an update
     const existingRsvp = await platform.env.RSVPS.prepare(
       'SELECT * FROM rsvps WHERE LOWER(name) = LOWER(?) OR LOWER(email) = LOWER(?)'

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -43,7 +43,7 @@ id = "REPLACE_WITH_YOUR_KV_ID"
 [[env.production.d1_databases]]
 binding = "RSVPS"
 database_name = "wedding-rsvps-prod"
-database_id = "REPLACE_WITH_YOUR_DATABASE_ID"
+database_id = "5f4ee888-0757-44bf-8a69-49566936ae45"
 
 [[env.production.r2_buckets]]
 binding = "IMAGES_BUCKET"


### PR DESCRIPTION
## Summary
- add ability to build RSVP email content separately
- expose sendEmailBlast helper
- new admin API endpoints for preview/test/blast
- extend RSVP admin page with preview and blast options
- document new email blast feature

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fda50cf8832181a61d24a702c780