### PR TITLE
Fix mobile nav overflow

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -149,8 +149,8 @@
 
 <header class="fixed w-full top-0 bg-white/90 backdrop-blur-sm shadow-sm z-50">
   {#if !isRestricted}
-    <nav class="max-w-4xl mx-auto px-4 py-4">
-      <ul class="flex gap-6 justify-center">
+    <nav class="max-w-4xl mx-auto px-4 py-4 overflow-x-auto">
+      <ul class="flex gap-6 justify-start sm:justify-center whitespace-nowrap">
         {#each allPages as pageItem}
           <li>
             <a


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for the navigation on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68589a669eb0832186d1a675314628ef